### PR TITLE
더보기 버튼 추가 및 메뉴 작동 문제 해결

### DIFF
--- a/src/components/DiscourseNoticeBanner.jsx
+++ b/src/components/DiscourseNoticeBanner.jsx
@@ -37,7 +37,7 @@ export default function DiscourseNoticeBanner(props) {
                     </Col>
                 ))}
             </Row>
-            <Row>
+            <Row style={{marginTop: "1em"}}>
                 <Col size={12} className="u-align-text--right">
                     <Button
                         appearance=""

--- a/src/components/DiscourseNoticeBanner.jsx
+++ b/src/components/DiscourseNoticeBanner.jsx
@@ -1,9 +1,12 @@
 
-import { Strip, Row, Col } from "@canonical/react-components";
+import { Strip, Row, Col, Button } from "@canonical/react-components";
 import { useState, useEffect } from "react";
+import { useTranslations } from "../i18n/utils";
 
 export default function DiscourseNoticeBanner(props) {
     const [ topicList, setTopicList ] = useState([]);
+    const [ moreTopic, setMoreTopic ] = useState([]);
+    const t = useTranslations(props.lang);
     useEffect(() => {
         fetch(`${props.baseUrl}${props.jsonFeedEndpoint}`)
             .then(res => res.json()).then(data => {
@@ -19,6 +22,7 @@ export default function DiscourseNoticeBanner(props) {
                         };
                     }).slice(0, 3);
                 setTopicList(filteredTopics);
+                setMoreTopic(data["topic_list"]["more_topics_url"]);
             })
     }, [])
     return (
@@ -32,6 +36,17 @@ export default function DiscourseNoticeBanner(props) {
                         <b>{item.date}</b>
                     </Col>
                 ))}
+            </Row>
+            <Row>
+                <Col size={12} className="u-align-text--right">
+                    <Button
+                        appearance=""
+                        element="a"
+                        href={moreTopic}
+                    >
+                        {t("discourseNoticeBanner.moreTopics")}
+                    </Button>
+                </Col>
             </Row>
         </Strip>
     )

--- a/src/components/NavigationMenu.jsx
+++ b/src/components/NavigationMenu.jsx
@@ -1,0 +1,28 @@
+import { useTranslations } from "../i18n/utils";
+import {
+	Navigation
+} from "@canonical/react-components";
+
+
+export default function NavigationMenu(props) {
+    const t = useTranslations(props.lang);
+
+    return(
+        <Navigation
+			items={[
+			]}
+			itemsRight={[
+				{
+					label: "ubuntu-kr.org",
+					url: "https://ubuntu-kr.org",
+				}
+			]}
+			logo={{
+				src: "/UbuntuKrCircleWhite.svg",
+				title: "UbuCon Korea 2023",
+				url: "/",
+			}}
+			theme="dark"
+		/>
+    )
+}

--- a/src/components/SponsorBanner.astro
+++ b/src/components/SponsorBanner.astro
@@ -41,7 +41,7 @@ const sponsorClassList = [
 											<img
 												class="p-logo-section__logo"
 												src={sponsor.data.logo}
-												alt="Verizon"
+												alt={sponsor.data.title}
 											/>
 										</a>
 									</div>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -20,7 +20,8 @@ export const ui = {
     'sponsorship.details': '후원사 등록하기',
     'cfp.title': '발표 제안 제출하기',
     'cfp.desc': '우분투를 개발 생산상을 향상하는데 활용해 본 경험이 있거나, 우분투 및 관련 오픈소스와 관련하여 공유하고 싶은 경험이 있다면, 오늘 발표 제안을 제출하여 발표자로 지원 해 보세요!',
-    'cfp.submit': '제안서 제출하기'
+    'cfp.submit': '제안서 제출하기',
+    'discourseNoticeBanner.moreTopics': '더 보기'
   },
   en: {
     'eventMeta.date': '9th September 2023',
@@ -35,7 +36,8 @@ export const ui = {
     'sponsorship.details': 'Become a sponsor',
     'cfp.title': 'Call for proposals',
     'cfp.desc': 'If you have any experience on boosting your developer productivity using Ubuntu, or have your own unique experience around Ubuntu and FOSS to share, Submit your proposal today and become a speaker!',
-    'cfp.submit': 'Submit proposal'
+    'cfp.submit': 'Submit proposal',
+    'discourseNoticeBanner.moreTopics': 'More Topics'
   },
 
 } as const;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,9 +12,7 @@ import { getLangFromUrl, useTranslations } from "../i18n/utils";
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 import SponsorBanner from "../components/SponsorBanner.astro";
-import {
-	Navigation,
-} from "@canonical/react-components";
+import NavigationMenu from "../components/NavigationMenu.jsx";
 import LanguagePicker from "../components/LanguagePicker.jsx";
 export function getStaticPaths() {
 	return [{ params: { lang: "en" } }, { params: { lang: "ko" } }];
@@ -36,20 +34,9 @@ export function getStaticPaths() {
 	</head>
 	<body>
 		<main>
-			<Navigation
-				items={[]}
-				itemsRight={[
-					{
-						label: "ubuntu-kr.org",
-						url: "https://ubuntu-kr.org",
-					},
-				]}
-				logo={{
-					src: "/UbuntuKrCircleWhite.svg",
-					title: "UbuCon Korea 2023",
-					url: "/",
-				}}
-				theme="dark"
+			<NavigationMenu
+				lang={lang}
+				client:only="react"
 			/>
 			<slot />
 			<SponsorBanner/>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -34,6 +34,7 @@ export function getStaticPaths() {
 		baseUrl="https://discourse.ubuntu-kr.org"
 		jsonFeedEndpoint="/c/notice/9.json?order=created"
 		topicTag="ubucon-kr-2023"
+		lang={lang}
 		client:only="react"
 	/>
 	<Strip bordered element="section" includeCol={false}>


### PR DESCRIPTION
다음 두 사항에 대해 작업하였습니다.

- 공지사항 섹션 우측 하단 더보기 버튼 추가
- 모바일 작동하지 않는 메뉴


또한 작업 중 아래 사항 확인하여 적용하였습니다.
- 스폰서 배너에서 대체 텍스트가 "Verizon"으로 고정되어 있는 현상 수정 (각 스폰서의 이름(title) 값으로 적용하였습니다)

2023.06.05. 23:16 기준 적용되어 있는 버튼은 1안 기준입니다.