### PR TITLE
스폰서 배너 관련 링크 수정

### DIFF
--- a/src/components/SponsorBanner.astro
+++ b/src/components/SponsorBanner.astro
@@ -37,7 +37,7 @@ const sponsorClassList = [
 									const [itemLang, ...slug] = sponsor.slug.split('/');
 									return (
 									<div class="p-logo-section__item">
-										<a href={`sponsors/${slug}`}>
+										<a href={`/${lang}/sponsors/${slug}`}>
 											<img
 												class="p-logo-section__logo"
 												src={sponsor.data.logo}


### PR DESCRIPTION
페이지 하단 스폰서 배너 관련, 메인 페이지가 아닌 다른 페이지에서 스폰서 항목을 클릭하면 잘못된 URL로 이동하는 현상을 수정하였습니다.

(**예시** `/ko/sponsor` 페이지에서 Microsoft 로고 클릭 시 `/ko/sponsor/sponsors/microsoft`로 이동했던 문제를 `/ko/sponsors/microsoft`로 정상적으로 이동하도록 수정)